### PR TITLE
Saving scratches to server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ __pycache__
 venv
 /.pytest_cache
 .env
-.jpeg
+*.jpeg

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 venv
 /.pytest_cache
 .env
+.jpeg

--- a/app.py
+++ b/app.py
@@ -252,22 +252,18 @@ def post_scratch():
                                  author_id=session_author_id,
                                  is_comment=False,
                                  return_scratch=True)
-    save_scratch_to_server(response,
-                           scratch_id=scratch.scratch_id,
-                           author_id=session_author_id)
-
-
+    save_scratch_to_server(response, scratch)
+    
     return redirect(f'/scratch/{scratch.scratch_id}', 200)
 
-def save_scratch_to_server(response, scratch_id, author_id):
+def save_scratch_to_server(response, scratch):
     image_data = response.get('image_uri').split(',')[1]
     binary_data = a2b_base64(image_data)
+    
+    scratch_img_folder = 'static/scratches/'
+    filename = scratch.scratch_filename
 
-    filename = srs.create_scratch_filename(
-        scratch_id=scratch_id,
-        user_id=author_id
-    )
-    with open(filename, 'wb') as file_writer:
+    with open(scratch_img_folder + filename, 'wb') as file_writer:
         file_writer.write(binary_data)  
         print(f"wrote to {filename}!!")
 

--- a/app.py
+++ b/app.py
@@ -106,6 +106,23 @@ def signup_post():
     return redirect(f'/user/{user.user_id}', 200)
 
 
+def validate_username(username):
+    if len(username) < ars.MINIMUM_FRONTEND_USERNAME_LENGTH:
+            raise ValueError(f'Username must be greater than ' + 
+                             f'{ars.MINIMUM_FRONTEND_USERNAME_LENGTH} characters long')
+    if len(username) > ars.MAXIMUM_FRONTEND_USERNAME_LENGTH:
+        raise ValueError(f'Username must be less than ' + 
+                            f'{ars.MAXIMUM_FRONTEND_USERNAME_LENGTH} characters long')
+
+def validate_password(user_password):
+    if len(user_password) < ars.MINIMUM_FRONTEND_PASSWORD_LENGTH:
+            raise ValueError(f'Password must be greater than ' +  
+                             f'{ars.MINIMUM_FRONTEND_PASSWORD_LENGTH} characters long')
+    if len(user_password) > ars.MAXIMUM_FRONTEND_PASSWORD_LENGTH:
+        raise ValueError(f'Password cannot be greater than ' +  
+                            f'{ars.MAXIMUM_FRONTEND_PASSWORD_LENGTH} characters long')                    
+
+
 def hash_password(password: str) -> str:
     hashed_bytes = bcrypt.generate_password_hash(password, num_rounds)
     hashed_password = hashed_bytes.decode('utf-8')

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS app_user (
 
 CREATE TABLE IF NOT EXISTS scratch (
 	scratch_id SERIAL NOT NULL,
+    scratch_filename VARCHAR(30) NULL, 
 	caption VARCHAR(30) NULL,
 	author_id INT NOT NULL,
 	is_comment BOOLEAN NOT NULL,
@@ -23,7 +24,7 @@ CREATE TABLE IF NOT EXISTS user_history (
     user_id INT NOT NULL,
     user_created_op_scratch BOOLEAN NOT NULL,
     user_commented BOOLEAN NOT NULL,
-    user_comment_scratch_id INT NOT NULL,
+    user_comment_scratch_id INT NULL,
     user_liked BOOLEAN NOT NULL,
     PRIMARY KEY (user_id, parent_scratch_id),
     FOREIGN KEY (user_id) REFERENCES app_user(user_id) ON UPDATE CASCADE ON DELETE CASCADE,

--- a/models.py
+++ b/models.py
@@ -8,13 +8,20 @@ db = SQLAlchemy()
 class Scratch(db.Model):
     MAX_CAPTION_LENGTH = 40
     MAX_DATE_LENGTH = 20
+    MAXMIMUM_FILENAME_LENGTH: int = 30
     __tablename__ = 'scratch'
+
     scratch_id = db.Column(db.Integer,
                            db.ForeignKey('commented_by.op_scratch_id'),
                            db.ForeignKey('liked_by.scratch_id'),
                            primary_key=True,
-                           autoincrement=True
+                           autoincrement=True,
+                           nullable=False
                            )
+    scratch_filename = db.Column(
+        db.String(MAXMIMUM_FILENAME_LENGTH),
+        nullable=True
+    )
     caption = db.Column(
         db.String(MAX_CAPTION_LENGTH),
         nullable=True

--- a/src/models/repositories.py
+++ b/src/models/repositories.py
@@ -16,19 +16,6 @@ class AppUserRepository():
         """ Creates a user, stores in the database, and returns the AppUser 
             instance if `return_user` is `True`
         """
-        if len(username) < AppUser.MINIMUM_FRONTEND_USERNAME_LENGTH:
-            raise ValueError(f'Username must be greater than ' + 
-                             f'{AppUser.MINIMUM_FRONTEND_USERNAME_LENGTH} characters long')
-        if len(username) > AppUser.MAXIMUM_FRONTEND_USERNAME_LENGTH:
-            raise ValueError(f'Username must be less than ' + 
-                             f'{AppUser.MAXIMUM_FRONTEND_USERNAME_LENGTH} characters long')
-        if len(user_password) < AppUser.MINIMUM_FRONTEND_PASSWORD_LENGTH:
-            raise ValueError(f'Password must be greater than ' +  
-                             f'{AppUser.MINIMUM_FRONTEND_PASSWORD_LENGTH} characters long')
-        if len(user_password) > AppUser.MAXIMUM_FRONTEND_PASSWORD_LENGTH:
-            raise ValueError(f'Password cannot be greater than ' +  
-                             f'{AppUser.MAXIMUM_FRONTEND_PASSWORD_LENGTH} characters long')
-
         new_user = AppUser(username=username,
                            user_password=user_password)
 
@@ -177,6 +164,41 @@ class ScratchRepository():
         db.session.commit()
         if return_scratch is True:
             return new_scratch
+
+    @staticmethod
+    def add_url_to_scratch(scratch_id: int,
+                           return_scratch: bool = True) -> None | Scratch:
+        vhs.validate_id_is_int_and_pos(scratch_id)
+        target_scratch = ScratchRepository.find_scratch_with_id(scratch_id)
+        filename = ScratchRepository.create_scratch_filename(target_scratch.scratch_id, target_scratch.author_id)
+        target_scratch.scratch_filename = filename
+        print(f'{target_scratch} had its filename updated to {filename}')
+        db.session.commit()
+
+    @staticmethod
+    def create_scratch_filename(scratch_id: int,
+                                user_id: int) -> str:
+        """Creates the filename for a given scratch id that 
+        takes the following form:
+
+        `scratch_id00user_id00scratch.date_created`
+
+        Args:
+            scratch_id (int): id of the scratch whose filename is being created
+            user_id (int): id of the user who created the scratch
+
+        Returns:
+            str: filename of the scratch
+        """
+        vhs.validate_id_is_int_and_pos(scratch_id)
+        vhs.validate_id_is_int_and_pos(user_id)
+        target_scratch = ScratchRepository.find_scratch_with_id(scratch_id)
+        date_created = target_scratch.date_created
+        stripped_date_created = ''.join(date_created.split('-'))
+        delim = '00'
+
+        filename: str = str(scratch_id) + delim + str(user_id) + delim + stripped_date_created
+        return filename
 
     @staticmethod
     def comment_on_scratch(img,  # TODO IMG VALIDATION HERE

--- a/src/models/repositories.py
+++ b/src/models/repositories.py
@@ -140,8 +140,7 @@ class ScratchRepository():
     """
 
     @staticmethod
-    def create_scratch(img,  # TODO IMG VALIDATION HERE
-                       *,
+    def create_scratch(*,
                        caption: str,
                        author_id: int,
                        is_comment: bool = False,
@@ -149,10 +148,41 @@ class ScratchRepository():
         """ Creates a scratch, stores in the database, and returns the
             Scratch instance if `return_scratch` is `True`.
         """
+
         new_scratch = Scratch(caption=caption,
                               author_id=author_id,
                               is_comment=is_comment)
+        print(f'\n\n\nCreating scratch in repositories.py,\n{new_scratch=}\n{new_scratch.scratch_id=}\n\n\n')
+        vhs.validate_obj_is_of_type(new_scratch, desired_type=Scratch)
+        db.session.add(new_scratch)
+        db.session.commit()
 
+        # Store in the user's history
+        just_created_scratch = AppUserRepository.get_scratches_by_author(author_id)[-1]
+        user_created_scratch_history = UserHistory(
+            user_id=author_id,
+            parent_scratch_id=just_created_scratch.scratch_id,
+            user_created_op_scratch=True
+        )
+        db.session.add(user_created_scratch_history)
+        db.session.commit()
+        if return_scratch is True:
+            return new_scratch
+
+    @staticmethod
+    def create_empty_scratch(*,
+                       caption: str,
+                       author_id: int,
+                       is_comment: bool = False,
+                       return_scratch=False) -> None | Scratch:
+        """ Creates a scratch, stores in the database, and returns the
+            Scratch instance if `return_scratch` is `True`.
+        """
+
+        new_scratch = Scratch(caption=caption,
+                              author_id=author_id,
+                              is_comment=is_comment)
+        print(f'\n\n\nCreating scratch in repositories.py,\n{new_scratch=}\n{new_scratch.scratch_id=}\n\n\n')
         vhs.validate_obj_is_of_type(new_scratch, desired_type=Scratch)
         user_created_scratch_history = UserHistory(
             user_id=author_id,
@@ -194,10 +224,11 @@ class ScratchRepository():
         vhs.validate_id_is_int_and_pos(user_id)
         target_scratch = ScratchRepository.find_scratch_with_id(scratch_id)
         date_created = target_scratch.date_created
-        stripped_date_created = ''.join(date_created.split('-'))
         delim = '00'
+        file_extension = '.jpeg'
+        stripped_date_created = str(date_created.month) + delim + str(date_created.day) + delim + str(date_created.year)
 
-        filename: str = str(scratch_id) + delim + str(user_id) + delim + stripped_date_created
+        filename: str = str(scratch_id) + delim + str(user_id) + delim + stripped_date_created + file_extension
         return filename
 
     @staticmethod

--- a/src/models/repositories.py
+++ b/src/models/repositories.py
@@ -159,6 +159,7 @@ class ScratchRepository():
 
         # Store in the user's history
         just_created_scratch = AppUserRepository.get_scratches_by_author(author_id)[-1]
+        ScratchRepository.add_url_to_scratch(just_created_scratch.scratch_id)
         user_created_scratch_history = UserHistory(
             user_id=author_id,
             parent_scratch_id=just_created_scratch.scratch_id,

--- a/src/models/repositories.py
+++ b/src/models/repositories.py
@@ -170,32 +170,6 @@ class ScratchRepository():
             return new_scratch
 
     @staticmethod
-    def create_empty_scratch(*,
-                       caption: str,
-                       author_id: int,
-                       is_comment: bool = False,
-                       return_scratch=False) -> None | Scratch:
-        """ Creates a scratch, stores in the database, and returns the
-            Scratch instance if `return_scratch` is `True`.
-        """
-
-        new_scratch = Scratch(caption=caption,
-                              author_id=author_id,
-                              is_comment=is_comment)
-        print(f'\n\n\nCreating scratch in repositories.py,\n{new_scratch=}\n{new_scratch.scratch_id=}\n\n\n')
-        vhs.validate_obj_is_of_type(new_scratch, desired_type=Scratch)
-        user_created_scratch_history = UserHistory(
-            user_id=author_id,
-            parent_scratch_id=new_scratch.scratch_id,
-            user_created_op_scratch=True
-        )
-        db.session.add(new_scratch)
-        db.session.add(user_created_scratch_history)
-        db.session.commit()
-        if return_scratch is True:
-            return new_scratch
-
-    @staticmethod
     def add_url_to_scratch(scratch_id: int,
                            return_scratch: bool = True) -> None | Scratch:
         vhs.validate_id_is_int_and_pos(scratch_id)

--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -175,10 +175,16 @@ colorPicker.addEventListener("change", () => {
 // Comment out if you need to test the drawing function as it currently breaks the js
 saveImg.addEventListener("click", () => {
     let image = canvas.toDataURL("image/jpeg", 1.0);
-    console.log(image);
-    fetch(`${window.origin}/imgProcessing`, { //Where we want to send the data + where we are located (assumption)
+    let caption = document.getElementById('caption');
+    let captionText = caption.value;    
+    data= {
+        image_uri: image,
+        caption: captionText
+    },
+    console.log(data);
+    fetch(`${window.origin}/compose/scratch/post`, { //Where we want to send the data + where we are located (assumption)
         method: "POST",
-        body: JSON.stringify(image),
+        body: JSON.stringify(data),
         cache: "no-cache",
         headers: new Headers({
             "Content-Type": "application/json"

--- a/templates/compose-scratch.html
+++ b/templates/compose-scratch.html
@@ -127,7 +127,7 @@
         </div>
     </div>
   </div>
-<form action="" method="post" class="" enctype="multipart/form-data">
+<form action="/compose/scratch/post" method="post" class="" enctype="multipart/form-data">
   <div class="login-form m-auto">
     <div class="mb-3">
       <input type="text" name="caption" id="caption" class="form-control" autocomplete="off" maxlength="20" placeholder="Caption (20 chars)">


### PR DESCRIPTION
@CesarCGuzman and I added made some core changes to saving images to the server.

Changes:
- Pressing "post" on the scratch composition page now saves an image of the scratch to the server, which can be later referred to when displaying scratches
    - Saves to `static/scratches/` directory
    - Filename is specific to each scratch and stores data which follows this naming system: 
    `scratch_id00user_id00MM00DD00YYYY`
- Scratch objects will store their filename in their entry in the database